### PR TITLE
WKT options and bulk operations

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,10 +8,12 @@ jobs:
         strategy:
             fail-fast: true
             matrix:
-                php: [8.0, 8.1]
+                php: [8.0, 8.1, 8.2]
                 laravel: [8.*, 9.*, 10.*]
                 stability: [prefer-lowest, prefer-stable]
                 include:
+                    - laravel: 10.*
+                      testbench: 8.*
                     - laravel: 9.*
                       testbench: 7.*
                     - laravel: 8.*

--- a/README.md
+++ b/README.md
@@ -148,6 +148,26 @@ return [
 ];
 ```
 ***
+#### Bulk Operations
+In order to insert or update several rows with spatial data in one query using the `upsert()` method in Laravel, the package requires a workaround solution to avoid the error `Object of class TarfinLabs\LaravelSpatial\Types\Point could not be converted to string`. 
+
+The solution is to use the `toGeomFromTextString()` method to convert the `Point` object to a WKT string, and then use `DB::raw()` to create a raw query string.
+
+Here's an example of how to use this workaround in your code:
+
+```php
+use TarfinLabs\LaravelSpatial\Types\Point;
+
+$points = [
+    ['external_id' => 5, 'location' => (new Point(50, 20))->toGeomFromTextString()],
+    ['external_id' => 7, 'location' => (new Point(60, 30))->toGeomFromTextString()],
+];
+
+Property::upsert($points, ['external_id'], ['location']);
+```
+
+
+***
 ### 4- Scopes:
 
 #### ***withinDistanceTo()***

--- a/README.md
+++ b/README.md
@@ -135,6 +135,19 @@ return [
 ];
 ```
 ***
+#### Configuring WKT options
+By default, this package uses the `longitude latitude` order for the coordinate values in the WKT format used by spatial functions. This is necessary for some versions of MySQL, which will interpret coordinate pairs as lat-long unless the `axis-order` option is explicitly set to `long-lat`.
+
+However, MariaDB reads WKT values as `long-lat` by default, and its spatial functions like `ST_GeomFromText` and `ST_DISTANCE` do not accept an `options` parameter like their MySQL counterparts. This means that using the package with MariaDB will result in a `Syntax error or access violation: 1582 Incorrect parameter count in the call to native function 'ST_GeomFromText'` exception.
+
+To address this issue, we have added a `with_wkt_options` parameter to the config file that can be used to override the default options. This property can be set to `false` to remove the options parameter entirely, which fixes the errors when using MariaDB.
+
+```php 
+return [
+    'with_wkt_options' => true,
+];
+```
+***
 ### 4- Scopes:
 
 #### ***withinDistanceTo()***

--- a/config/config.php
+++ b/config/config.php
@@ -1,5 +1,6 @@
 <?php
 
 return [
-    'default_srid' => null,
+    'default_srid'     => null,
+    'with_wkt_options' => true,
 ];

--- a/src/Casts/LocationCast.php
+++ b/src/Casts/LocationCast.php
@@ -41,9 +41,7 @@ class LocationCast implements CastsAttributes, SerializesCastableAttributes
         }
 
         if ($value->getSrid() > 0) {
-            return DB::raw(
-                value: "ST_GeomFromText('{$value->toWkt()}', {$value->getSrid()}, 'axis-order=long-lat')"
-            );
+            return DB::raw($value->toGeomFromText());
         }
 
         return DB::raw(value: "ST_GeomFromText('{$value->toWkt()}')");

--- a/src/Traits/HasSpatial.php
+++ b/src/Traits/HasSpatial.php
@@ -68,8 +68,12 @@ trait HasSpatial
     {
         $raw = '';
 
+        $wktOptions = config('laravel-spatial.wkt_options', true) === true
+            ? ', \'axis-order=long-lat\''
+            : '';
+
         foreach ($this->getLocationCastedAttributes() as $column) {
-            $raw .= "CONCAT(ST_AsText({$this->getTable()}.{$column}, 'axis-order=long-lat'), ',', ST_SRID({$this->getTable()}.{$column})) as {$column}, ";
+            $raw .= "CONCAT(ST_AsText({$this->getTable()}.{$column}$wktOptions), ',', ST_SRID({$this->getTable()}.{$column})) as {$column}, ";
         }
 
         $raw = substr($raw, 0, -2);

--- a/src/Types/Point.php
+++ b/src/Types/Point.php
@@ -53,6 +53,11 @@ class Point
         return "{$this->getLng()} {$this->getLat()}";
     }
 
+    public function toGeomFromText(): string
+    {
+        return "ST_GeomFromText('{$this->toWkt()}', {$this->getSrid()}{$this->wktOptions})";
+    }
+
     public function toArray(): array
     {
         return [

--- a/src/Types/Point.php
+++ b/src/Types/Point.php
@@ -12,6 +12,8 @@ class Point
 
     protected int $srid;
 
+    protected string $wktOptions;
+
     public function __construct(float $lat = 0, float $lng = 0, ?int $srid = null)
     {
         $this->lat = $lat;
@@ -20,6 +22,10 @@ class Point
         $this->srid = is_null($srid)
             ? config('laravel-spatial.default_srid') ?? 0
             : $srid;
+
+        $this->wktOptions = config('laravel-spatial.wkt_options', true) === true
+            ? ', \'axis-order=long-lat\''
+            : '';
     }
 
     public function getLat(): float

--- a/tests/PointTest.php
+++ b/tests/PointTest.php
@@ -79,6 +79,22 @@ class PointTest extends TestCase
         $this->assertSame("{$point->getLng()} {$point->getLat()}", $pair);
     }
 
+    /**
+     * @test
+     * @see
+     */
+    public function it_returns_points_as_geometry(): void
+    {
+        // 1. Arrange
+        $point = new Point(25.1515, 36.1212, 4326);
+
+        // 2. Act
+        $geometry = $point->toGeomFromText();
+
+        // 3. Assert
+        $this->assertSame("ST_GeomFromText('{$point->toWkt()}', {$point->getSrid()}, 'axis-order=long-lat')", $geometry);
+    }
+
     /** @test */
     public function it_returns_points_as_array(): void
     {


### PR DESCRIPTION
This pr adds the following developments:

- Add `with_wkt_options` config parameter to use this package with MariaDB database
- Add `toGeomFromTextString()` method to `Point` class in order to use the class with `upsert()` operations.

This pull request fixes the issues #14 and #16 