### PR TITLE
Update LocationCast.php

### DIFF
--- a/src/Casts/LocationCast.php
+++ b/src/Casts/LocationCast.php
@@ -17,6 +17,10 @@ class LocationCast implements CastsAttributes, SerializesCastableAttributes
     {
         if (is_null($value)) {
             return null;
+        }        
+        
+        if (gettype($value) !== "string") {
+            return null;
         }
 
         $coordinates = explode(',', $value);


### PR DESCRIPTION
Fixes the error

explode(): Argument #2 ($string) must be of type string, Illuminate\Database\Query\Expression given