### PR TITLE
Fix for MariaDB Compatibility with ST_SRID Function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to `laravel-spatial` will be documented in this file
 
+## 2.0.1 - 2024-11-27
+- Fix the incorrect parameter count error while using `ST_SRID` functions with `MariaDB`.
+
+## 2.0.0 - 2024-07-25
+- Added Laravel 11 and PHP 8.3 support
+
 ## 1.7.0 - 2023-05-11
 - PHP 8.2 support added.
 


### PR DESCRIPTION
This pull request addresses an issue reported in #31 where MariaDB does not support the second parameter for the ST_SRID() function, as documented [here](https://mariadb.com/kb/en/st_srid/).

The issue caused errors like the following when using the package with Laravel’s MariaDB driver:

```bash
SQLSTATE[42000]: Syntax error or access violation:
1582 Incorrect parameter count in the call to native function 'ST_SRID'
```

### Changes Made:

- Updated the usage of `ST_SRID()` to exclude the second parameter when the connection is identified as MariaDB.
- Ensured compatibility across all affected scopes in the `HasSpatial` trait.

### Impact:
This fix resolves compatibility issues with MariaDB and ensures the package functions seamlessly for users relying on MariaDB drivers.

Thank you @jangaraev for your feedback and for highlighting this issue! Your support and use of the package are greatly appreciated.
