### PR TITLE
Fix spatial queries by explicitly referencing table names

### DIFF
--- a/src/Traits/HasSpatial.php
+++ b/src/Traits/HasSpatial.php
@@ -15,7 +15,7 @@ trait HasSpatial
     public function scopeSelectDistanceTo(Builder $query, string $column, Point $point): void
     {
         if (is_null($query->getQuery()->columns)) {
-            $query->select('*');
+            $query->select("{$this->getTable()}.*");
         }
 
         match (DB::connection()->getDriverName()) {
@@ -59,7 +59,7 @@ trait HasSpatial
 
         $raw = substr($raw, 0, -2);
 
-        return parent::newQuery()->addSelect('*', DB::raw($raw));
+        return parent::newQuery()->addSelect("{$this->getTable()}.*", DB::raw($raw));
     }
 
     public function getLocationCastedAttributes(): Collection

--- a/tests/HasSpatialTest.php
+++ b/tests/HasSpatialTest.php
@@ -19,7 +19,7 @@ class HasSpatialTest extends TestCase
 
         // Assert
         $this->assertEquals(
-            expected: "select *, CONCAT(ST_AsText(addresses.$castedAttr, 'axis-order=long-lat'), ',', ST_SRID(addresses.$castedAttr)) as $castedAttr, ST_Distance(ST_SRID($castedAttr, ?), ST_SRID(Point(?, ?), ?)) as distance from `addresses`",
+            expected: "select `addresses`.*, CONCAT(ST_AsText(addresses.$castedAttr, 'axis-order=long-lat'), ',', ST_SRID(addresses.$castedAttr)) as $castedAttr, ST_Distance(ST_SRID($castedAttr, ?), ST_SRID(Point(?, ?), ?)) as distance from `addresses`",
             actual: $query->toSql()
         );
     }
@@ -36,7 +36,7 @@ class HasSpatialTest extends TestCase
 
         // 3. Assert
         $this->assertEquals(
-            expected: "select *, CONCAT(ST_AsText(addresses.$castedAttr, 'axis-order=long-lat'), ',', ST_SRID(addresses.$castedAttr)) as $castedAttr from `addresses` where ST_AsText(location) != ? and ST_Distance(ST_SRID($castedAttr, ?), ST_SRID(Point(?, ?), ?)) <= ?",
+            expected: "select `addresses`.*, CONCAT(ST_AsText(addresses.$castedAttr, 'axis-order=long-lat'), ',', ST_SRID(addresses.$castedAttr)) as $castedAttr from `addresses` where ST_AsText(location) != ? and ST_Distance(ST_SRID($castedAttr, ?), ST_SRID(Point(?, ?), ?)) <= ?",
             actual: $query->toSql()
         );
     }
@@ -54,12 +54,12 @@ class HasSpatialTest extends TestCase
 
         // 3. Assert
         $this->assertEquals(
-            expected: "select *, CONCAT(ST_AsText(addresses.$castedAttr, 'axis-order=long-lat'), ',', ST_SRID(addresses.$castedAttr)) as $castedAttr from `addresses` order by ST_Distance(ST_SRID($castedAttr, ?), ST_SRID(Point(?, ?), ?)) asc",
+            expected: "select `addresses`.*, CONCAT(ST_AsText(addresses.$castedAttr, 'axis-order=long-lat'), ',', ST_SRID(addresses.$castedAttr)) as $castedAttr from `addresses` order by ST_Distance(ST_SRID($castedAttr, ?), ST_SRID(Point(?, ?), ?)) asc",
             actual: $queryForAsc->toSql()
         );
 
         $this->assertEquals(
-            expected: "select *, CONCAT(ST_AsText(addresses.$castedAttr, 'axis-order=long-lat'), ',', ST_SRID(addresses.$castedAttr)) as $castedAttr from `addresses` order by ST_Distance(ST_SRID($castedAttr, ?), ST_SRID(Point(?, ?), ?)) desc",
+            expected: "select `addresses`.*, CONCAT(ST_AsText(addresses.$castedAttr, 'axis-order=long-lat'), ',', ST_SRID(addresses.$castedAttr)) as $castedAttr from `addresses` order by ST_Distance(ST_SRID($castedAttr, ?), ST_SRID(Point(?, ?), ?)) desc",
             actual: $queryForDesc->toSql()
         );
     }
@@ -73,7 +73,7 @@ class HasSpatialTest extends TestCase
 
         // 2. Act & Assert
         $this->assertEquals(
-            expected: "select *, CONCAT(ST_AsText(addresses.$castedAttr, 'axis-order=long-lat'), ',', ST_SRID(addresses.$castedAttr)) as $castedAttr from `addresses`",
+            expected: "select `addresses`.*, CONCAT(ST_AsText(addresses.$castedAttr, 'axis-order=long-lat'), ',', ST_SRID(addresses.$castedAttr)) as $castedAttr from `addresses`",
             actual: $address->query()->toSql()
         );
     }


### PR DESCRIPTION
### Overview
This PR builds upon and expands the changes introduced in [#33](https://github.com/tarfin-labs/laravel-spatial/pull/33). While the original PR addressed an issue with spatial queries, this PR refines the implementation further to ensure explicit table references in SELECT queries, reducing ambiguity and improving query reliability. As a result, PR [#33](https://github.com/tarfin-labs/laravel-spatial/pull/33) will be closed in favor of this one.

### Changes
- Updated `scopeSelectDistanceTo` and `newQuery` methods in `HasSpatial` to use `{$this->getTable()}.*` instead of `*.`
- Updated test assertions in `HasSpatialTest` to reflect these changes.

### Why?
- Avoids ambiguity when joining multiple tables.
- Ensures better SQL readability and maintainability.
- Prevents unexpected query behavior due to implicit column selection.

### Testing
- Updated unit tests to assert queries include explicit table references.
- All tests pass successfully.

### Notes
This change is fully backward-compatible and does not alter existing behavior beyond ensuring explicit table references.

### Checklist
- Code changes reviewed and tested.
- Unit tests updated accordingly.
- No breaking changes introduced.