### PR TITLE
Handling expression in location cast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `laravel-spatial` will be documented in this file
 
+## 3.0.1 - 2025-05-14
+- Expression support added to `get()` method in `LocationCast`.
+- Replaced `@test` annotations with `#[Test]` attributes across the test suite for modern PHPUnit syntax.
+
 ## 3.0.0 - 2025-02-20
 - Laravel 12 and PHP 8.4 support added.
 - Laravel 10 and below versions are not supported anymore.

--- a/tests/HasSpatialTest.php
+++ b/tests/HasSpatialTest.php
@@ -2,12 +2,13 @@
 
 namespace TarfinLabs\LaravelSpatial\Tests;
 
+use PHPUnit\Framework\Attributes\Test;
 use TarfinLabs\LaravelSpatial\Tests\TestModels\Address;
 use TarfinLabs\LaravelSpatial\Types\Point;
 
 class HasSpatialTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function it_generates_sql_query_for_selectDistanceTo_scope(): void
     {
         // Arrange
@@ -24,7 +25,7 @@ class HasSpatialTest extends TestCase
         );
     }
 
-    /** @test */
+    #[Test]
     public function it_generates_sql_query_for_withinDistanceTo_scope(): void
     {
         // 1. Arrange
@@ -41,7 +42,7 @@ class HasSpatialTest extends TestCase
         );
     }
 
-    /** @test */
+    #[Test]
     public function it_generates_sql_query_for_orderByDistanceTo_scope(): void
     {
         // 1. Arrange
@@ -64,7 +65,7 @@ class HasSpatialTest extends TestCase
         );
     }
 
-    /** @test */
+    #[Test]
     public function it_generates_sql_query_for_location_casted_attributes(): void
     {
         // 1. Arrange
@@ -78,7 +79,7 @@ class HasSpatialTest extends TestCase
         );
     }
 
-    /** @test */
+    #[Test]
     public function it_returns_location_casted_attributes(): void
     {
         // 1. Arrange

--- a/tests/LocationCastTest.php
+++ b/tests/LocationCastTest.php
@@ -2,15 +2,17 @@
 
 namespace TarfinLabs\LaravelSpatial\Tests;
 
+use Illuminate\Database\Query\Expression;
 use InvalidArgumentException;
 use Illuminate\Support\Facades\DB;
+use PHPUnit\Framework\Attributes\Test;
 use TarfinLabs\LaravelSpatial\Casts\LocationCast;
 use TarfinLabs\LaravelSpatial\Tests\TestModels\Address;
 use TarfinLabs\LaravelSpatial\Types\Point;
 
 class LocationCastTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function it_throws_an_exception_if_casted_attribute_set_to_a_non_point_value(): void
     {
         // 1. Arrange
@@ -23,7 +25,7 @@ class LocationCastTest extends TestCase
         $address->location = 'dummy';
     }
 
-    /** @test */
+    #[Test]
     public function it_can_set_the_casted_attribute_to_a_point(): void
     {
         // 1. Arrange
@@ -39,7 +41,7 @@ class LocationCastTest extends TestCase
         $this->assertEquals(DB::raw("ST_GeomFromText('{$point->toWkt()}', 4326, 'axis-order=long-lat')"), $response);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_set_the_casted_attribute_to_a_point_with_srid(): void
     {
         // 1. Arrange
@@ -55,7 +57,7 @@ class LocationCastTest extends TestCase
         $this->assertEquals(DB::raw("ST_GeomFromText('{$point->toWkt()}', {$point->getSrid()}, 'axis-order=long-lat')"), $response);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_get_a_casted_attribute(): void
     {
         // 1. Arrange
@@ -73,7 +75,25 @@ class LocationCastTest extends TestCase
         $this->assertEquals($point->getSrid(), $address->location->getSrid());
     }
 
-    /** @test */
+    #[Test]
+    public function it_can_get_a_casted_attribute_using_expression(): void
+    {
+        // 1. Arrange
+        $address = new Address();
+        $point = new Point(27.1234, 39.1234);
+
+        // 2. Act
+        $cast   = new LocationCast();
+        $result = $cast->get($address, 'location', new Expression($point->toGeomFromText()), $address->getAttributes());
+
+        // 3. Assert
+        $this->assertInstanceOf(Point::class, $result);
+        $this->assertEquals($point->getLat(), $result->getLat());
+        $this->assertEquals($point->getLng(), $result->getLng());
+        $this->assertEquals($point->getSrid(), $result->getSrid());
+    }
+
+    #[Test]
     public function it_returns_null_if_the_value_of_the_casted_column_is_null(): void
     {
         // 1. Arrange
@@ -86,7 +106,7 @@ class LocationCastTest extends TestCase
         $this->assertNull($address->location);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_serialize_a_casted_attribute(): void
     {
         // 1. Arrange

--- a/tests/PointTest.php
+++ b/tests/PointTest.php
@@ -5,11 +5,12 @@ declare(strict_types=1);
 namespace TarfinLabs\LaravelSpatial\Tests;
 
 use Illuminate\Support\Facades\Config;
+use PHPUnit\Framework\Attributes\Test;
 use TarfinLabs\LaravelSpatial\Types\Point;
 
 class PointTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function it_sets_lat_lng_and_srid_in_constructor(): void
     {
         // 1. Arrange
@@ -26,7 +27,7 @@ class PointTest extends TestCase
         $this->assertSame(expected: $srid, actual: $point->getSrid());
     }
 
-    /** @test */
+    #[Test]
     public function it_returns_default_lat_lng_and_srid_if_they_are_not_given_in_the_constructor(): void
     {
         // 1. Act
@@ -38,7 +39,7 @@ class PointTest extends TestCase
         $this->assertSame(expected: 4326, actual: $point->getSrid());
     }
 
-    /** @test */
+    #[Test]
     public function it_returns_default_srid_in_config_if_it_is_not_null(): void
     {
         // 1. Arrange
@@ -53,7 +54,7 @@ class PointTest extends TestCase
         $this->assertSame(expected: 4326, actual: $point->getSrid());
     }
 
-    /** @test */
+    #[Test]
     public function it_returns_point_as_wkt(): void
     {
         // 1. Arrange
@@ -66,7 +67,7 @@ class PointTest extends TestCase
         $this->assertSame("POINT({$point->getLng()} {$point->getLat()})", $wkt);
     }
 
-    /** @test */
+    #[Test]
     public function it_returns_point_as_pair(): void
     {
         // 1. Arrange
@@ -79,10 +80,7 @@ class PointTest extends TestCase
         $this->assertSame("{$point->getLng()} {$point->getLat()}", $pair);
     }
 
-    /**
-     * @test
-     * @see
-     */
+    #[Test]
     public function it_returns_points_as_geometry(): void
     {
         // 1. Arrange
@@ -95,7 +93,7 @@ class PointTest extends TestCase
         $this->assertSame("ST_GeomFromText('{$point->toWkt()}', {$point->getSrid()}, 'axis-order=long-lat')", $geometry);
     }
 
-    /** @test */
+    #[Test]
     public function it_returns_points_as_array(): void
     {
         // 1. Arrange


### PR DESCRIPTION
This pull request introduces enhancements to the `laravel-spatial` package, focusing on adding expression support for the `LocationCast` class, modernizing the test suite with PHPUnit attributes, and improving test coverage. Below are the most significant changes grouped by theme:

### Enhancements to `LocationCast` functionality:
* Added support for handling `Expression` objects in the `get()` method of `LocationCast` by introducing a private `getCoordinates()` method. This allows parsing spatial expressions like `ST_GeomFromText` to extract coordinates. (`src/Casts/LocationCast.php`) [[1]](diffhunk://#diff-3b1dc61459093ddfe08133486af822da4e61961c6ed7bdb9f033196fac5703c2L22-R22) [[2]](diffhunk://#diff-3b1dc61459093ddfe08133486af822da4e61961c6ed7bdb9f033196fac5703c2R54-R71)

### Modernization of the test suite:
* Replaced `@test` annotations with `#[Test]` attributes across all test methods for compatibility with modern PHPUnit syntax. (`tests/HasSpatialTest.php`, `tests/LocationCastTest.php`, `tests/PointTest.php`) [[1]](diffhunk://#diff-91f53936f7ffc1741f9ee6d6c6311f45b8f3791e9b5cddd0126f58fe6269f02bR5-R11) [[2]](diffhunk://#diff-d886b90a09ff1b6c1deb8664b0b2a71e74092661a511c6ecec6a98408c37c4c6R5-R15) [[3]](diffhunk://#diff-1f7f6863181e73d0918c3928bb74e36f1ea68eaa4943308bfff1b58d59ac8054R8-R13)

### Improved test coverage:
* Added a new test case to verify that the `get()` method in `LocationCast` correctly handles `Expression` objects and returns a `Point` instance. (`tests/LocationCastTest.php`)

### Documentation updates:
* Updated the `CHANGELOG.md` file to document the new features and changes introduced in version `3.0.1`. (`CHANGELOG.md`)