### PR TITLE
Handling expression in location cast v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to `laravel-spatial` will be documented in this file
 
+## 2.2.0 - 2025-05-15
+- Expression support added to `get()` method in `LocationCast`.
+
 ## 2.1.0 - 2025-02-20
 - Removed support for Laravel 11 due to incompatibility with the current implementation.
 

--- a/tests/LocationCastTest.php
+++ b/tests/LocationCastTest.php
@@ -2,6 +2,7 @@
 
 namespace TarfinLabs\LaravelSpatial\Tests;
 
+use Illuminate\Database\Query\Expression;
 use InvalidArgumentException;
 use Illuminate\Support\Facades\DB;
 use TarfinLabs\LaravelSpatial\Casts\LocationCast;
@@ -71,6 +72,24 @@ class LocationCastTest extends TestCase
         $this->assertEquals($point->getLat(), $address->location->getLat());
         $this->assertEquals($point->getLng(), $address->location->getLng());
         $this->assertEquals($point->getSrid(), $address->location->getSrid());
+    }
+
+    /** @test */
+    public function it_can_get_a_casted_attribute_using_expression(): void
+    {
+        // 1. Arrange
+        $address = new Address();
+        $point = new Point(27.1234, 39.1234);
+
+        // 2. Act
+        $cast   = new LocationCast();
+        $result = $cast->get($address, 'location', new Expression($point->toGeomFromText()), $address->getAttributes());
+
+        // 3. Assert
+        $this->assertInstanceOf(Point::class, $result);
+        $this->assertEquals($point->getLat(), $result->getLat());
+        $this->assertEquals($point->getLng(), $result->getLng());
+        $this->assertEquals($point->getSrid(), $result->getSrid());
     }
 
     /** @test */


### PR DESCRIPTION
This pull request introduces support for handling database expressions in the `get()` method of the `LocationCast` class, along with corresponding tests. The key updates include refactoring the `get()` method, adding a helper method for parsing expressions, and expanding test coverage to verify the new functionality.

### Enhancements to `LocationCast` functionality:

* Added support for database expressions in the `get()` method by introducing a new private helper method, `getCoordinates`, to handle parsing of `ST_GeomFromText` expressions. (`src/Casts/LocationCast.php`: [[1]](diffhunk://#diff-3b1dc61459093ddfe08133486af822da4e61961c6ed7bdb9f033196fac5703c2L22-R22) [[2]](diffhunk://#diff-3b1dc61459093ddfe08133486af822da4e61961c6ed7bdb9f033196fac5703c2R54-R71)

### Test coverage improvements:

* Added a new test, `it_can_get_a_casted_attribute_using_expression`, to validate that the `get()` method correctly processes attributes provided as database expressions. (`tests/LocationCastTest.php`: [tests/LocationCastTest.phpR77-R94](diffhunk://#diff-d886b90a09ff1b6c1deb8664b0b2a71e74092661a511c6ecec6a98408c37c4c6R77-R94))
* Included the necessary `Expression` import to support the new test. (`tests/LocationCastTest.php`: [tests/LocationCastTest.phpR5](diffhunk://#diff-d886b90a09ff1b6c1deb8664b0b2a71e74092661a511c6ecec6a98408c37c4c6R5))

### Documentation updates:

* Updated the `CHANGELOG.md` file to document the addition of expression support in the `get()` method for version 2.2.0. (`CHANGELOG.md`: [CHANGELOG.mdR5-R7](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR5-R7))