### PR TITLE
fix/distance parameter type for v2.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to `laravel-spatial` will be documented in this file
 
+## 2.2.1 - 2025-06-12
+- Fixed `$distance` parameter type from `int` to `float` in `scopeWithinDistanceTo` and related methods to properly handle decimal distance values returned by `ST_Distance` function.
+
 ## 2.2.0 - 2025-05-15
 - Expression support added to `get()` method in `LocationCast`.
 

--- a/src/Traits/HasSpatial.php
+++ b/src/Traits/HasSpatial.php
@@ -25,7 +25,7 @@ trait HasSpatial
         };
     }
 
-    public function scopeWithinDistanceTo(Builder $query, string $column, Point $point, int $distance): void
+    public function scopeWithinDistanceTo(Builder $query, string $column, Point $point, float $distance): void
     {
         match (DB::connection()->getDriverName()) {
             'pgsql', 'mysql' => $this->withinDistanceToMysqlAndPostgres($query, $column, $point, $distance),
@@ -91,7 +91,7 @@ trait HasSpatial
         );
     }
 
-    private function withinDistanceToMysqlAndPostgres(Builder $query, string $column, Point $point, int $distance): Builder
+    private function withinDistanceToMysqlAndPostgres(Builder $query, string $column, Point $point, float $distance): Builder
     {
         return $query
             ->whereRaw("ST_AsText({$column}) != ?", [
@@ -111,7 +111,7 @@ trait HasSpatial
             );
     }
 
-    private function withinDistanceToMariaDb(Builder $query, string $column, Point $point, int $distance): Builder
+    private function withinDistanceToMariaDb(Builder $query, string $column, Point $point, float $distance): Builder
     {
         return $query
             ->whereRaw("ST_AsText({$column}) != ?", [


### PR DESCRIPTION
This pull request addresses a type mismatch issue in the `scopeWithinDistanceTo` method and related methods in the `laravel-spatial` package. The `$distance` parameter type has been updated from `int` to `float` to better handle decimal distance values returned by the `ST_Distance` function. The changes ensure compatibility with spatial queries that rely on precise distance calculations.

### Parameter Type Update for Spatial Methods:

* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR5-R7): Documented the fix for `$distance` parameter type from `int` to `float` in `scopeWithinDistanceTo` and related methods.
* [`src/Traits/HasSpatial.php`](diffhunk://#diff-8fa4ecc9982e0985829510274a951b022588e8be8c90e6fca5cbe23eb7edab8eL28-R28): Updated the `$distance` parameter type in the `scopeWithinDistanceTo` method from `int` to `float`.
* [`src/Traits/HasSpatial.php`](diffhunk://#diff-8fa4ecc9982e0985829510274a951b022588e8be8c90e6fca5cbe23eb7edab8eL94-R94): Updated the `$distance` parameter type in the `withinDistanceToMysqlAndPostgres` private method from `int` to `float`.
* [`src/Traits/HasSpatial.php`](diffhunk://#diff-8fa4ecc9982e0985829510274a951b022588e8be8c90e6fca5cbe23eb7edab8eL114-R114): Updated the `$distance` parameter type in the `withinDistanceToMariaDb` private method from `int` to `float`.