### PR TITLE
feat: add Laravel 13 and PHP 8.5 support (3.2.0)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,9 +21,12 @@ jobs:
         strategy:
             fail-fast: true
             matrix:
-                php: [8.2, 8.3, 8.4]
-                laravel: [11, 12]
+                php: [8.2, 8.3, 8.4, 8.5]
+                laravel: [11, 12, 13]
                 stability: [prefer-lowest, prefer-stable]
+                exclude:
+                    - php: 8.2
+                      laravel: 13
 
         name: P${{ matrix.php }} - L${{ matrix.laravel }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to `laravel-spatial` will be documented in this file
 
+## 3.2.0 - 2026-04-02
+- Laravel 13 and PHP 8.5 support added.
+
 ## 3.1.1 - 2025-06-12
 - Fixed `$distance` parameter type from `int` to `float` in `scopeWithinDistanceTo` and related methods to properly handle decimal distance values returned by `ST_Distance` function.
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ It supports only MySQL Spatial Data Types and Functions, other RDBMS is on the r
 
 | Version | Supported Laravel Versions |
 |---------|----------------------------|
-| `3.x`   | `^11.0`, `^12.0`           |
+| `3.x`   | `^11.0`, `^12.0`, `^13.0`  |
 | `2.x`   | `^8.0, ^9.0, ^10.0`        |
 
 **Supported data types:**

--- a/composer.json
+++ b/composer.json
@@ -16,13 +16,13 @@
     }
   ],
   "require": {
-    "php": "^8.2|^8.3|^8.4",
-    "illuminate/support": "^11.0|^12.0"
+    "php": "^8.2|^8.3|^8.4|^8.5",
+    "illuminate/support": "^11.0|^12.0|^13.0"
   },
   "require-dev": {
     "doctrine/dbal": "^3.3",
-    "orchestra/testbench": "^9.0|^10.0",
-    "phpunit/phpunit": "^10.0|^11.0"
+    "orchestra/testbench": "^9.0|^10.0|^11.0",
+    "phpunit/phpunit": "^10.0|^11.0|^12.0"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
## Summary
  - Extends `composer.json` constraints to support Laravel 13 (`^13.0`) and PHP 8.5 (`^8.5`)
  - Updates `orchestra/testbench` to `^11.0` and `phpunit/phpunit` to `^12.0` for Laravel 13 compatibility
  - Adds PHP 8.5 and Laravel 13 to the CI matrix; excludes PHP 8.2 + Laravel 13 combination (Laravel 13 requires PHP ^8.3  
  minimum)

  ## Test plan                                                                                                             
  - [x] CI matrix runs green for all PHP/Laravel combinations
  - [x] PHP 8.2 + Laravel 13 is correctly excluded from the matrix
  - [x] `composer update` resolves without conflicts on Laravel 13 + PHP 8.5