### PR TITLE
fix: avoid duplicate column names in newQuery() causing LocationCast to receive binary WKB

### DIFF
--- a/src/Traits/HasSpatial.php
+++ b/src/Traits/HasSpatial.php
@@ -51,6 +51,7 @@ trait HasSpatial
         static $columnListingCache = [];
 
         $table = $this->getTable();
+        $spatialColumns = $this->getLocationCastedAttributes();
         
         $raw = '';
 
@@ -58,7 +59,7 @@ trait HasSpatial
             ? ', \'axis-order=long-lat\''
             : '';
 
-        foreach ($this->getLocationCastedAttributes() as $column) {
+        foreach ($spatialColumns as $column) {
             $raw .= "CONCAT(ST_AsText({$table}.{$column}$wktOptions), ',', ST_SRID({$table}.{$column})) as {$column}, ";
         }
 
@@ -69,7 +70,7 @@ trait HasSpatial
         }
 
         $selects = collect($columnListingCache[$table])
-            ->diff($this->getLocationCastedAttributes())
+            ->diff($spatialColumns)
             ->map(fn($col) => "{$table}.{$col}")
             ->push(DB::raw($raw))
             ->all();

--- a/src/Traits/HasSpatial.php
+++ b/src/Traits/HasSpatial.php
@@ -7,6 +7,7 @@ namespace TarfinLabs\LaravelSpatial\Traits;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
 use TarfinLabs\LaravelSpatial\Casts\LocationCast;
 use TarfinLabs\LaravelSpatial\Types\Point;
 
@@ -47,6 +48,10 @@ trait HasSpatial
 
     public function newQuery(): Builder
     {
+        static $columnListingCache = [];
+
+        $table = $this->getTable();
+        
         $raw = '';
 
         $wktOptions = config('laravel-spatial.with_wkt_options', true) === true
@@ -54,12 +59,22 @@ trait HasSpatial
             : '';
 
         foreach ($this->getLocationCastedAttributes() as $column) {
-            $raw .= "CONCAT(ST_AsText({$this->getTable()}.{$column}$wktOptions), ',', ST_SRID({$this->getTable()}.{$column})) as {$column}, ";
+            $raw .= "CONCAT(ST_AsText({$table}.{$column}$wktOptions), ',', ST_SRID({$table}.{$column})) as {$column}, ";
         }
 
         $raw = substr($raw, 0, -2);
 
-        return parent::newQuery()->addSelect("{$this->getTable()}.*", DB::raw($raw));
+        if (!isset($columnListingCache[$table])) {
+            $columnListingCache[$table] = Schema::getColumnListing($table);
+        }
+
+        $selects = collect($columnListingCache[$table])
+            ->diff($this->getLocationCastedAttributes())
+            ->map(fn($col) => "{$table}.{$col}")
+            ->push(DB::raw($raw))
+            ->all();
+
+        return parent::newQuery()->select($selects);
     }
 
     public function getLocationCastedAttributes(): Collection

--- a/tests/HasSpatialTest.php
+++ b/tests/HasSpatialTest.php
@@ -20,7 +20,7 @@ class HasSpatialTest extends TestCase
 
         // Assert
         $this->assertEquals(
-            expected: "select `addresses`.*, CONCAT(ST_AsText(addresses.$castedAttr, 'axis-order=long-lat'), ',', ST_SRID(addresses.$castedAttr)) as $castedAttr, ST_Distance(ST_SRID($castedAttr, ?), ST_SRID(Point(?, ?), ?)) as distance from `addresses`",
+            expected: "select `addresses`.`id`, `addresses`.`created_at`, `addresses`.`updated_at`, CONCAT(ST_AsText(addresses.$castedAttr, 'axis-order=long-lat'), ',', ST_SRID(addresses.$castedAttr)) as $castedAttr, ST_Distance(ST_SRID($castedAttr, ?), ST_SRID(Point(?, ?), ?)) as distance from `addresses`",
             actual: $query->toSql()
         );
     }
@@ -37,7 +37,7 @@ class HasSpatialTest extends TestCase
 
         // 3. Assert
         $this->assertEquals(
-            expected: "select `addresses`.*, CONCAT(ST_AsText(addresses.$castedAttr, 'axis-order=long-lat'), ',', ST_SRID(addresses.$castedAttr)) as $castedAttr from `addresses` where ST_AsText(location) != ? and ST_Distance(ST_SRID($castedAttr, ?), ST_SRID(Point(?, ?), ?)) <= ?",
+            expected: "select `addresses`.`id`, `addresses`.`created_at`, `addresses`.`updated_at`, CONCAT(ST_AsText(addresses.$castedAttr, 'axis-order=long-lat'), ',', ST_SRID(addresses.$castedAttr)) as $castedAttr from `addresses` where ST_AsText(location) != ? and ST_Distance(ST_SRID($castedAttr, ?), ST_SRID(Point(?, ?), ?)) <= ?",
             actual: $query->toSql()
         );
     }
@@ -55,12 +55,12 @@ class HasSpatialTest extends TestCase
 
         // 3. Assert
         $this->assertEquals(
-            expected: "select `addresses`.*, CONCAT(ST_AsText(addresses.$castedAttr, 'axis-order=long-lat'), ',', ST_SRID(addresses.$castedAttr)) as $castedAttr from `addresses` order by ST_Distance(ST_SRID($castedAttr, ?), ST_SRID(Point(?, ?), ?)) asc",
+            expected: "select `addresses`.`id`, `addresses`.`created_at`, `addresses`.`updated_at`, CONCAT(ST_AsText(addresses.$castedAttr, 'axis-order=long-lat'), ',', ST_SRID(addresses.$castedAttr)) as $castedAttr from `addresses` order by ST_Distance(ST_SRID($castedAttr, ?), ST_SRID(Point(?, ?), ?)) asc",
             actual: $queryForAsc->toSql()
         );
-
+        
         $this->assertEquals(
-            expected: "select `addresses`.*, CONCAT(ST_AsText(addresses.$castedAttr, 'axis-order=long-lat'), ',', ST_SRID(addresses.$castedAttr)) as $castedAttr from `addresses` order by ST_Distance(ST_SRID($castedAttr, ?), ST_SRID(Point(?, ?), ?)) desc",
+            expected: "select `addresses`.`id`, `addresses`.`created_at`, `addresses`.`updated_at`, CONCAT(ST_AsText(addresses.$castedAttr, 'axis-order=long-lat'), ',', ST_SRID(addresses.$castedAttr)) as $castedAttr from `addresses` order by ST_Distance(ST_SRID($castedAttr, ?), ST_SRID(Point(?, ?), ?)) desc",
             actual: $queryForDesc->toSql()
         );
     }
@@ -74,7 +74,7 @@ class HasSpatialTest extends TestCase
 
         // 2. Act & Assert
         $this->assertEquals(
-            expected: "select `addresses`.*, CONCAT(ST_AsText(addresses.$castedAttr, 'axis-order=long-lat'), ',', ST_SRID(addresses.$castedAttr)) as $castedAttr from `addresses`",
+            expected: "select `addresses`.`id`, `addresses`.`created_at`, `addresses`.`updated_at`, CONCAT(ST_AsText(addresses.$castedAttr, 'axis-order=long-lat'), ',', ST_SRID(addresses.$castedAttr)) as $castedAttr from `addresses`",
             actual: $address->query()->toSql()
         );
     }


### PR DESCRIPTION
### Problem
HasSpatial::newQuery() called select with `'*'`:

```php
parent::newQuery()->addSelect("{$table}.*", DB::raw("CONCAT(ST_AsText({$table}.location...) as location"))
```
This produces two columns named location in the result set — one binary WKB from `table.*`, one WKT string from the raw expression. PDO resolves the conflict by returning the binary value, so LocationCast::get() receives unparseable data and fails.

The problem was already raised at: https://github.com/tarfin-labs/laravel-spatial/issues/26

### Fix
Instead of selecting `table.*` (which includes the raw spatial column), let's retrieve the table's column listing explicitly, exclude spatial columns from it, then append only the WKT conversion expressions. This guarantees no duplicate column names in the result.

A static local cache (`$columnListingCache`) is used to avoid a repeated `Schema::getColumnListing()` DB round-trip — the listing is fetched once per table per process and reused for all subsequent queries.

### Result
`->location->getLat()` / `->location->getLng()` now work correctly on models using `HasSpatial` trait without requiring workarounds like storing coordinates in a separate columns.