### PR TITLE
Implemented Region (Polygon) geographical type and support.

### DIFF
--- a/src/Casts/RegionCast.php
+++ b/src/Casts/RegionCast.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TarfinLabs\LaravelSpatial\Casts;
+
+use InvalidArgumentException;
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+use Illuminate\Contracts\Database\Eloquent\SerializesCastableAttributes;
+use Illuminate\Database\Query\Expression;
+use Illuminate\Support\Facades\DB;
+use TarfinLabs\LaravelSpatial\Types\Point;
+use TarfinLabs\LaravelSpatial\Types\Polygon;
+
+class RegionCast implements CastsAttributes, SerializesCastableAttributes
+{
+    public function get($model, string $key, $value, array $attributes): ?Polygon
+    {
+        if (is_null($value)) {
+            return null;
+        }
+
+        $coordinates = $this->getCoordinates($model, $value);
+
+        if (count($coordinates) > 1) {
+            return $this->parsePolygon($coordinates[0], (int) $coordinates[1]);
+        }
+
+        return $this->parsePolygon($value);
+    }
+
+    public function set($model, string $key, $value, array $attributes): Expression
+    {
+        if (!$value instanceof Polygon) {
+            throw new InvalidArgumentException(
+                sprintf('The %s field must be instance of %s', $key, Polygon::class)
+            );
+        }
+
+        if ($value->getSrid() > 0) {
+            return DB::raw($value->toGeomFromText());
+        }
+
+        return DB::raw(value: "ST_GeomFromText('{$value->toWkt()}')");
+    }
+
+    public function serialize($model, string $key, $value, array $attributes): array
+    {
+        return $value->toArray();
+    }
+
+    private function parsePolygon(string $wkt, int $srid = 0): Polygon
+    {
+        preg_match('/POLYGON\(\((.+)\)\)/', $wkt, $matches);
+
+        $pairs = explode(',', $matches[1]);
+
+        $points = array_map(function (string $pair) {
+            $coords = explode(' ', trim($pair));
+
+            return new Point(lat: (float) $coords[1], lng: (float) $coords[0], srid: null);
+        }, $pairs);
+
+        return new Polygon($points, $srid > 0 ? $srid : null);
+    }
+
+    private function getCoordinates($model, $value): array
+    {
+        if ($value instanceof Expression) {
+            preg_match(
+                pattern: "/ST_GeomFromText\(\s*'([^']+)'\s*(?:,\s*(\d+))?\s*(?:,\s*'([^']+)')?\s*\)/",
+                subject: (string) $value->getValue($model->getConnection()->getQueryGrammar()),
+                matches: $matches,
+            );
+
+            return [
+                $matches[1],
+                (int) ($matches[2] ?? 0),
+            ];
+        }
+
+        $lastComma = strrpos($value, ',');
+
+        return [
+            substr($value, 0, $lastComma),
+            (int) substr($value, $lastComma + 1),
+        ];
+    }
+}

--- a/src/Traits/HasSpatial.php
+++ b/src/Traits/HasSpatial.php
@@ -7,6 +7,7 @@ namespace TarfinLabs\LaravelSpatial\Traits;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
+use TarfinLabs\LaravelSpatial\Casts\RegionCast;
 use TarfinLabs\LaravelSpatial\Casts\LocationCast;
 use TarfinLabs\LaravelSpatial\Types\Point;
 
@@ -53,7 +54,9 @@ trait HasSpatial
             ? ', \'axis-order=long-lat\''
             : '';
 
-        foreach ($this->getLocationCastedAttributes() as $column) {
+        $spatialAttributes = $this->getLocationCastedAttributes()->merge($this->getRegionCastedAttributes());
+
+        foreach ($spatialAttributes as $column) {
             $raw .= "CONCAT(ST_AsText({$this->getTable()}.{$column}$wktOptions), ',', ST_SRID({$this->getTable()}.{$column})) as {$column}, ";
         }
 
@@ -65,6 +68,11 @@ trait HasSpatial
     public function getLocationCastedAttributes(): Collection
     {
         return collect($this->getCasts())->filter(fn ($cast) => $cast === LocationCast::class)->keys();
+    }
+
+    public function getRegionCastedAttributes(): Collection
+    {
+        return collect($this->getCasts())->filter(fn ($cast) => $cast === RegionCast::class)->keys();
     }
 
     private function selectDistanceToMysqlAndPostgres(Builder $query, string $column, Point $point): Builder

--- a/src/Types/Polygon.php
+++ b/src/Types/Polygon.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TarfinLabs\LaravelSpatial\Types;
+
+use InvalidArgumentException;
+
+class Polygon
+{
+    /** @var Point[] */
+    protected array $points;
+
+    protected int $srid;
+
+    protected string $wktOptions;
+
+    /**
+     * @param  Point[]  $points
+     */
+    public function __construct(array $points, ?int $srid = 4326)
+    {
+        foreach ($points as $point) {
+            if (!$point instanceof Point) {
+                throw new InvalidArgumentException('All points must be instances of ' . Point::class);
+            }
+        }
+
+        if (count($points) < 3) {
+            throw new InvalidArgumentException('A polygon must have at least 3 unique points.');
+        }
+
+        $first = $points[0];
+        $last = end($points);
+
+        if ($first->getLat() !== $last->getLat() || $first->getLng() !== $last->getLng()) {
+            $points[] = clone $first;
+        }
+
+        $this->points = array_values($points);
+
+        $this->srid = is_null($srid)
+            ? config('laravel-spatial.default_srid') ?? 0
+            : $srid;
+
+        $this->wktOptions = config('laravel-spatial.with_wkt_options', true) === true
+            ? ', \'axis-order=long-lat\''
+            : '';
+    }
+
+    /**
+     * @return Point[]
+     */
+    public function getPoints(): array
+    {
+        return $this->points;
+    }
+
+    public function getSrid(): int
+    {
+        return $this->srid;
+    }
+
+    public function toPairs(): string
+    {
+        return implode(',', array_map(fn (Point $point) => $point->toPair(), $this->points));
+    }
+
+    public function toWkt(): string
+    {
+        return sprintf('POLYGON((%s))', $this->toPairs());
+    }
+
+    public function toGeomFromText(): string
+    {
+        return "ST_GeomFromText('{$this->toWkt()}', {$this->getSrid()}{$this->wktOptions})";
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'points' => array_map(fn (Point $point) => [
+                'lat' => $point->getLat(),
+                'lng' => $point->getLng(),
+            ], $this->points),
+            'srid' => $this->srid,
+        ];
+    }
+}

--- a/tests/HasSpatialPointTest.php
+++ b/tests/HasSpatialPointTest.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace TarfinLabs\LaravelSpatial\Tests;
+
+use PHPUnit\Framework\Attributes\Test;
+use TarfinLabs\LaravelSpatial\Tests\TestModels\Address;
+use TarfinLabs\LaravelSpatial\Types\Point;
+
+class HasSpatialPointTest extends TestCase
+{
+    #[Test]
+    public function it_generates_sql_query_for_selectDistanceTo_scope(): void
+    {
+        // Arrange
+        $address = new Address();
+        $castedAttr = $address->getLocationCastedAttributes()->first();
+
+        // Act
+        $query = $address->selectDistanceTo($castedAttr, new Point());
+
+        // Assert
+        $this->assertEquals(
+            expected: "select `addresses`.*, CONCAT(ST_AsText(addresses.$castedAttr, 'axis-order=long-lat'), ',', ST_SRID(addresses.$castedAttr)) as $castedAttr, ST_Distance(ST_SRID($castedAttr, ?), ST_SRID(Point(?, ?), ?)) as distance from `addresses`",
+            actual: $query->toSql()
+        );
+    }
+
+    #[Test]
+    public function it_generates_sql_query_for_withinDistanceTo_scope(): void
+    {
+        // 1. Arrange
+        $address = new Address();
+        $castedAttr = $address->getLocationCastedAttributes()->first();
+
+        // 2. Act
+        $query = $address->withinDistanceTo($castedAttr, new Point(), 10000);
+
+        // 3. Assert
+        $this->assertEquals(
+            expected: "select `addresses`.*, CONCAT(ST_AsText(addresses.$castedAttr, 'axis-order=long-lat'), ',', ST_SRID(addresses.$castedAttr)) as $castedAttr from `addresses` where ST_AsText(location) != ? and ST_Distance(ST_SRID($castedAttr, ?), ST_SRID(Point(?, ?), ?)) <= ?",
+            actual: $query->toSql()
+        );
+    }
+
+    #[Test]
+    public function it_generates_sql_query_for_orderByDistanceTo_scope(): void
+    {
+        // 1. Arrange
+        $address = new Address();
+        $castedAttr = $address->getLocationCastedAttributes()->first();
+
+        // 2. Act
+        $queryForAsc = $address->orderByDistanceTo($castedAttr, new Point());
+        $queryForDesc = $address->orderByDistanceTo($castedAttr, new Point(), 'desc');
+
+        // 3. Assert
+        $this->assertEquals(
+            expected: "select `addresses`.*, CONCAT(ST_AsText(addresses.$castedAttr, 'axis-order=long-lat'), ',', ST_SRID(addresses.$castedAttr)) as $castedAttr from `addresses` order by ST_Distance(ST_SRID($castedAttr, ?), ST_SRID(Point(?, ?), ?)) asc",
+            actual: $queryForAsc->toSql()
+        );
+
+        $this->assertEquals(
+            expected: "select `addresses`.*, CONCAT(ST_AsText(addresses.$castedAttr, 'axis-order=long-lat'), ',', ST_SRID(addresses.$castedAttr)) as $castedAttr from `addresses` order by ST_Distance(ST_SRID($castedAttr, ?), ST_SRID(Point(?, ?), ?)) desc",
+            actual: $queryForDesc->toSql()
+        );
+    }
+
+    #[Test]
+    public function it_generates_sql_query_for_location_casted_attributes(): void
+    {
+        // 1. Arrange
+        $address = new Address();
+        $castedAttr = $address->getLocationCastedAttributes()->first();
+
+        // 2. Act & Assert
+        $this->assertEquals(
+            expected: "select `addresses`.*, CONCAT(ST_AsText(addresses.$castedAttr, 'axis-order=long-lat'), ',', ST_SRID(addresses.$castedAttr)) as $castedAttr from `addresses`",
+            actual: $address->query()->toSql()
+        );
+    }
+
+    #[Test]
+    public function it_returns_location_casted_attributes(): void
+    {
+        // 1. Arrange
+        $address = new Address();
+
+        // 2. Act
+        $locationCastedAttributres = $address->getLocationCastedAttributes();
+
+        // 3. Assert
+        $this->assertEquals(collect(['location']), $locationCastedAttributres);
+    }
+}

--- a/tests/HasSpatialPolygonTest.php
+++ b/tests/HasSpatialPolygonTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace TarfinLabs\LaravelSpatial\Tests;
+
+use PHPUnit\Framework\Attributes\Test;
+use TarfinLabs\LaravelSpatial\Tests\TestModels\Place;
+
+class HasSpatialPolygonTest extends TestCase
+{
+    #[Test]
+    public function it_generates_sql_query_for_area_casted_attributes(): void
+    {
+        // 1. Arrange
+        $place = new Place();
+        $castedAttr = $place->getRegionCastedAttributes()->first();
+
+        // 2. Act & Assert
+        $this->assertEquals(
+            expected: "select `places`.*, CONCAT(ST_AsText(places.$castedAttr, 'axis-order=long-lat'), ',', ST_SRID(places.$castedAttr)) as $castedAttr from `places`",
+            actual: $place->query()->toSql()
+        );
+    }
+
+    #[Test]
+    public function it_returns_area_casted_attributes(): void
+    {
+        // 1. Arrange
+        $place = new Place();
+
+        // 2. Act
+        $areaCastedAttributes = $place->getRegionCastedAttributes();
+
+        // 3. Assert
+        $this->assertEquals(collect(['area']), $areaCastedAttributes);
+    }
+}

--- a/tests/HasSpatialTest.php
+++ b/tests/HasSpatialTest.php
@@ -3,92 +3,93 @@
 namespace TarfinLabs\LaravelSpatial\Tests;
 
 use PHPUnit\Framework\Attributes\Test;
-use TarfinLabs\LaravelSpatial\Tests\TestModels\Address;
+use TarfinLabs\LaravelSpatial\Tests\TestModels\Region;
 use TarfinLabs\LaravelSpatial\Types\Point;
 
 class HasSpatialTest extends TestCase
 {
     #[Test]
-    public function it_generates_sql_query_for_selectDistanceTo_scope(): void
+    public function it_returns_both_location_and_area_casted_attributes(): void
     {
-        // Arrange
-        $address = new Address();
-        $castedAttr = $address->getLocationCastedAttributes()->first();
+        // 1. Arrange
+        $region = new Region();
 
-        // Act
-        $query = $address->selectDistanceTo($castedAttr, new Point());
+        // 2. Act
+        $locationAttributes = $region->getLocationCastedAttributes();
+        $areaAttributes = $region->getRegionCastedAttributes();
 
-        // Assert
+        // 3. Assert
+        $this->assertEquals(collect(['location']), $locationAttributes);
+        $this->assertEquals(collect(['area']), $areaAttributes);
+    }
+
+    #[Test]
+    public function it_generates_sql_query_with_both_spatial_columns_in_select(): void
+    {
+        // 1. Arrange
+        $region = new Region();
+
+        // 2. Act
+        $sql = $region->query()->toSql();
+
+        // 3. Assert
         $this->assertEquals(
-            expected: "select `addresses`.*, CONCAT(ST_AsText(addresses.$castedAttr, 'axis-order=long-lat'), ',', ST_SRID(addresses.$castedAttr)) as $castedAttr, ST_Distance(ST_SRID($castedAttr, ?), ST_SRID(Point(?, ?), ?)) as distance from `addresses`",
+            expected: "select `regions`.*, CONCAT(ST_AsText(regions.location, 'axis-order=long-lat'), ',', ST_SRID(regions.location)) as location, CONCAT(ST_AsText(regions.area, 'axis-order=long-lat'), ',', ST_SRID(regions.area)) as area from `regions`",
+            actual: $sql
+        );
+    }
+
+    #[Test]
+    public function it_generates_sql_query_for_selectDistanceTo_with_both_spatial_columns(): void
+    {
+        // 1. Arrange
+        $region = new Region();
+
+        // 2. Act
+        $query = $region->selectDistanceTo('location', new Point());
+
+        // 3. Assert
+        $this->assertEquals(
+            expected: "select `regions`.*, CONCAT(ST_AsText(regions.location, 'axis-order=long-lat'), ',', ST_SRID(regions.location)) as location, CONCAT(ST_AsText(regions.area, 'axis-order=long-lat'), ',', ST_SRID(regions.area)) as area, ST_Distance(ST_SRID(location, ?), ST_SRID(Point(?, ?), ?)) as distance from `regions`",
             actual: $query->toSql()
         );
     }
 
     #[Test]
-    public function it_generates_sql_query_for_withinDistanceTo_scope(): void
+    public function it_generates_sql_query_for_withinDistanceTo_with_both_spatial_columns(): void
     {
         // 1. Arrange
-        $address = new Address();
-        $castedAttr = $address->getLocationCastedAttributes()->first();
+        $region = new Region();
 
         // 2. Act
-        $query = $address->withinDistanceTo($castedAttr, new Point(), 10000);
+        $query = $region->withinDistanceTo('location', new Point(), 10000);
 
         // 3. Assert
         $this->assertEquals(
-            expected: "select `addresses`.*, CONCAT(ST_AsText(addresses.$castedAttr, 'axis-order=long-lat'), ',', ST_SRID(addresses.$castedAttr)) as $castedAttr from `addresses` where ST_AsText(location) != ? and ST_Distance(ST_SRID($castedAttr, ?), ST_SRID(Point(?, ?), ?)) <= ?",
+            expected: "select `regions`.*, CONCAT(ST_AsText(regions.location, 'axis-order=long-lat'), ',', ST_SRID(regions.location)) as location, CONCAT(ST_AsText(regions.area, 'axis-order=long-lat'), ',', ST_SRID(regions.area)) as area from `regions` where ST_AsText(location) != ? and ST_Distance(ST_SRID(location, ?), ST_SRID(Point(?, ?), ?)) <= ?",
             actual: $query->toSql()
         );
     }
 
     #[Test]
-    public function it_generates_sql_query_for_orderByDistanceTo_scope(): void
+    public function it_generates_sql_query_for_orderByDistanceTo_with_both_spatial_columns(): void
     {
         // 1. Arrange
-        $address = new Address();
-        $castedAttr = $address->getLocationCastedAttributes()->first();
+        $region = new Region();
 
         // 2. Act
-        $queryForAsc = $address->orderByDistanceTo($castedAttr, new Point());
-        $queryForDesc = $address->orderByDistanceTo($castedAttr, new Point(), 'desc');
+        $queryForAsc = $region->orderByDistanceTo('location', new Point());
+        $queryForDesc = $region->orderByDistanceTo('location', new Point(), 'desc');
 
         // 3. Assert
         $this->assertEquals(
-            expected: "select `addresses`.*, CONCAT(ST_AsText(addresses.$castedAttr, 'axis-order=long-lat'), ',', ST_SRID(addresses.$castedAttr)) as $castedAttr from `addresses` order by ST_Distance(ST_SRID($castedAttr, ?), ST_SRID(Point(?, ?), ?)) asc",
+            expected: "select `regions`.*, CONCAT(ST_AsText(regions.location, 'axis-order=long-lat'), ',', ST_SRID(regions.location)) as location, CONCAT(ST_AsText(regions.area, 'axis-order=long-lat'), ',', ST_SRID(regions.area)) as area from `regions` order by ST_Distance(ST_SRID(location, ?), ST_SRID(Point(?, ?), ?)) asc",
             actual: $queryForAsc->toSql()
         );
 
         $this->assertEquals(
-            expected: "select `addresses`.*, CONCAT(ST_AsText(addresses.$castedAttr, 'axis-order=long-lat'), ',', ST_SRID(addresses.$castedAttr)) as $castedAttr from `addresses` order by ST_Distance(ST_SRID($castedAttr, ?), ST_SRID(Point(?, ?), ?)) desc",
+            expected: "select `regions`.*, CONCAT(ST_AsText(regions.location, 'axis-order=long-lat'), ',', ST_SRID(regions.location)) as location, CONCAT(ST_AsText(regions.area, 'axis-order=long-lat'), ',', ST_SRID(regions.area)) as area from `regions` order by ST_Distance(ST_SRID(location, ?), ST_SRID(Point(?, ?), ?)) desc",
             actual: $queryForDesc->toSql()
         );
-    }
-
-    #[Test]
-    public function it_generates_sql_query_for_location_casted_attributes(): void
-    {
-        // 1. Arrange
-        $address = new Address();
-        $castedAttr = $address->getLocationCastedAttributes()->first();
-
-        // 2. Act & Assert
-        $this->assertEquals(
-            expected: "select `addresses`.*, CONCAT(ST_AsText(addresses.$castedAttr, 'axis-order=long-lat'), ',', ST_SRID(addresses.$castedAttr)) as $castedAttr from `addresses`",
-            actual: $address->query()->toSql()
-        );
-    }
-
-    #[Test]
-    public function it_returns_location_casted_attributes(): void
-    {
-        // 1. Arrange
-        $address = new Address();
-
-        // 2. Act
-        $locationCastedAttributres = $address->getLocationCastedAttributes();
-
-        // 3. Assert
-        $this->assertEquals(collect(['location']), $locationCastedAttributres);
     }
 }

--- a/tests/PolygonTest.php
+++ b/tests/PolygonTest.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TarfinLabs\LaravelSpatial\Tests;
+
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\Test;
+use TarfinLabs\LaravelSpatial\Types\Point;
+use TarfinLabs\LaravelSpatial\Types\Polygon;
+
+class PolygonTest extends TestCase
+{
+    private function makeTrianglePoints(): array
+    {
+        return [
+            new Point(lat: 0, lng: 0, srid: null),
+            new Point(lat: 0, lng: 1, srid: null),
+            new Point(lat: 1, lng: 1, srid: null),
+        ];
+    }
+
+    #[Test]
+    public function it_creates_a_polygon_with_points(): void
+    {
+        // 1. Arrange & Act
+        $polygon = new Polygon($this->makeTrianglePoints(), 4326);
+
+        // 2. Assert
+        $this->assertCount(4, $polygon->getPoints());
+        $this->assertSame(4326, $polygon->getSrid());
+    }
+
+    #[Test]
+    public function it_auto_closes_the_polygon(): void
+    {
+        // 1. Arrange
+        $points = $this->makeTrianglePoints();
+
+        // 2. Act
+        $polygon = new Polygon($points);
+
+        // 3. Assert
+        $allPoints = $polygon->getPoints();
+        $first = $allPoints[0];
+        $last = end($allPoints);
+        $this->assertSame($first->getLat(), $last->getLat());
+        $this->assertSame($first->getLng(), $last->getLng());
+    }
+
+    #[Test]
+    public function it_does_not_double_close_an_already_closed_polygon(): void
+    {
+        // 1. Arrange
+        $points = $this->makeTrianglePoints();
+        $points[] = clone $points[0];
+
+        // 2. Act
+        $polygon = new Polygon($points);
+
+        // 3. Assert
+        $this->assertCount(4, $polygon->getPoints());
+    }
+
+    #[Test]
+    public function it_throws_an_exception_with_fewer_than_3_points(): void
+    {
+        // 1. Expect
+        $this->expectException(InvalidArgumentException::class);
+
+        // 2. Act
+        new Polygon([
+            new Point(lat: 0, lng: 0, srid: null),
+            new Point(lat: 1, lng: 1, srid: null),
+        ]);
+    }
+
+    #[Test]
+    public function it_throws_an_exception_with_non_point_values(): void
+    {
+        // 1. Expect
+        $this->expectException(InvalidArgumentException::class);
+
+        // 2. Act
+        new Polygon(['not', 'points', 'here']);
+    }
+
+    #[Test]
+    public function it_returns_polygon_as_wkt(): void
+    {
+        // 1. Arrange
+        $polygon = new Polygon($this->makeTrianglePoints());
+
+        // 2. Act
+        $wkt = $polygon->toWkt();
+
+        // 3. Assert
+        $this->assertSame('POLYGON((0 0,1 0,1 1,0 0))', $wkt);
+    }
+
+    #[Test]
+    public function it_returns_polygon_as_pairs(): void
+    {
+        // 1. Arrange
+        $polygon = new Polygon($this->makeTrianglePoints());
+
+        // 2. Act
+        $pairs = $polygon->toPairs();
+
+        // 3. Assert
+        $this->assertSame('0 0,1 0,1 1,0 0', $pairs);
+    }
+
+    #[Test]
+    public function it_returns_polygon_as_geometry(): void
+    {
+        // 1. Arrange
+        $polygon = new Polygon($this->makeTrianglePoints(), 4326);
+
+        // 2. Act
+        $geometry = $polygon->toGeomFromText();
+
+        // 3. Assert
+        $this->assertSame("ST_GeomFromText('{$polygon->toWkt()}', 4326, 'axis-order=long-lat')", $geometry);
+    }
+
+    #[Test]
+    public function it_returns_polygon_as_array(): void
+    {
+        // 1. Arrange
+        $polygon = new Polygon($this->makeTrianglePoints(), 4326);
+
+        // 2. Act
+        $array = $polygon->toArray();
+
+        // 3. Assert
+        $this->assertArrayHasKey('points', $array);
+        $this->assertArrayHasKey('srid', $array);
+        $this->assertCount(4, $array['points']);
+        $this->assertSame(4326, $array['srid']);
+        $this->assertSame(0.0, $array['points'][0]['lat']);
+        $this->assertSame(0.0, $array['points'][0]['lng']);
+    }
+}

--- a/tests/RegionCastTest.php
+++ b/tests/RegionCastTest.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace TarfinLabs\LaravelSpatial\Tests;
+
+use Illuminate\Database\Query\Expression;
+use InvalidArgumentException;
+use Illuminate\Support\Facades\DB;
+use PHPUnit\Framework\Attributes\Test;
+use TarfinLabs\LaravelSpatial\Casts\RegionCast;
+use TarfinLabs\LaravelSpatial\Tests\TestModels\Place;
+use TarfinLabs\LaravelSpatial\Types\Point;
+use TarfinLabs\LaravelSpatial\Types\Polygon;
+
+class RegionCastTest extends TestCase
+{
+    private function makeTrianglePolygon(): Polygon
+    {
+        return new Polygon([
+            new Point(lat: 0, lng: 0, srid: null),
+            new Point(lat: 0, lng: 1, srid: null),
+            new Point(lat: 1, lng: 1, srid: null),
+        ], 4326);
+    }
+
+    #[Test]
+    public function it_throws_an_exception_if_casted_attribute_set_to_a_non_polygon_value(): void
+    {
+        // 1. Arrange
+        $address = new Place();
+
+        // 2. Expect
+        $this->expectException(InvalidArgumentException::class);
+
+        // 3. Act
+        $address->area = 'dummy';
+    }
+
+    #[Test]
+    public function it_can_set_the_casted_attribute_to_a_polygon(): void
+    {
+        // 1. Arrange
+        $address = new Place();
+        $polygon = $this->makeTrianglePolygon();
+
+        $cast = new RegionCast();
+
+        // 2. Act
+        $response = $cast->set($address, 'area', $polygon, $address->getAttributes());
+
+        // 3. Assert
+        $this->assertEquals(DB::raw("ST_GeomFromText('{$polygon->toWkt()}', 4326, 'axis-order=long-lat')"), $response);
+    }
+
+    #[Test]
+    public function it_can_set_the_casted_attribute_to_a_polygon_with_srid(): void
+    {
+        // 1. Arrange
+        $address = new Place();
+        $polygon = new Polygon([
+            new Point(lat: 0, lng: 0, srid: null),
+            new Point(lat: 0, lng: 1, srid: null),
+            new Point(lat: 1, lng: 1, srid: null),
+        ], 4326);
+
+        $cast = new RegionCast();
+
+        // 2. Act
+        $response = $cast->set($address, 'area', $polygon, $address->getAttributes());
+
+        // 3. Assert
+        $this->assertEquals(DB::raw("ST_GeomFromText('{$polygon->toWkt()}', {$polygon->getSrid()}, 'axis-order=long-lat')"), $response);
+    }
+
+    #[Test]
+    public function it_can_get_a_casted_attribute(): void
+    {
+        // 1. Arrange
+        $address = new Place();
+        $polygon = $this->makeTrianglePolygon();
+
+        // 2. Act
+        $address->area = $polygon;
+        $address->save();
+
+        // 3. Assert
+        $this->assertInstanceOf(Polygon::class, $address->area);
+        $this->assertCount(count($polygon->getPoints()), $address->area->getPoints());
+        $this->assertEquals($polygon->getSrid(), $address->area->getSrid());
+    }
+
+    #[Test]
+    public function it_can_get_a_casted_attribute_using_expression(): void
+    {
+        // 1. Arrange
+        $address = new Place();
+        $polygon = $this->makeTrianglePolygon();
+
+        // 2. Act
+        $cast   = new RegionCast();
+        $result = $cast->get($address, 'area', new Expression($polygon->toGeomFromText()), $address->getAttributes());
+
+        // 3. Assert
+        $this->assertInstanceOf(Polygon::class, $result);
+        $this->assertCount(count($polygon->getPoints()), $result->getPoints());
+        $this->assertEquals($polygon->getSrid(), $result->getSrid());
+    }
+
+    #[Test]
+    public function it_returns_null_if_the_value_of_the_casted_column_is_null(): void
+    {
+        // 1. Arrange
+        $address = new Place();
+
+        // 2. Act
+        $address->save();
+
+        // 3. Assert
+        $this->assertNull($address->area);
+    }
+
+    #[Test]
+    public function it_can_serialize_a_casted_attribute(): void
+    {
+        // 1. Arrange
+        $address = new Place();
+        $polygon = $this->makeTrianglePolygon();
+
+        // 2. Act
+        $address->area = $polygon;
+        $address->save();
+
+        // 3. Assert
+        $array = $address->toArray();
+        $this->assertIsArray($array);
+        $this->assertArrayHasKey('area', $array);
+        $this->assertArrayHasKey('points', $array['area']);
+        $this->assertArrayHasKey('srid', $array['area']);
+
+        $this->assertJson($address->toJson());
+    }
+}

--- a/tests/TestModels/Place.php
+++ b/tests/TestModels/Place.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TarfinLabs\LaravelSpatial\Tests\TestModels;
+
+use Illuminate\Database\Eloquent\Model;
+use TarfinLabs\LaravelSpatial\Casts\RegionCast;
+use TarfinLabs\LaravelSpatial\Traits\HasSpatial;
+use TarfinLabs\LaravelSpatial\Types\Polygon;
+
+/**
+ * Class Place
+ *
+ * @property Polygon area
+ */
+class Place extends Model
+{
+    use HasSpatial;
+
+    protected $fillable = [
+        'area',
+    ];
+
+    protected $casts = [
+        'area' => RegionCast::class,
+    ];
+}

--- a/tests/TestModels/Region.php
+++ b/tests/TestModels/Region.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TarfinLabs\LaravelSpatial\Tests\TestModels;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use TarfinLabs\LaravelSpatial\Casts\RegionCast;
+use TarfinLabs\LaravelSpatial\Casts\LocationCast;
+use TarfinLabs\LaravelSpatial\Traits\HasSpatial;
+use TarfinLabs\LaravelSpatial\Types\Point;
+use TarfinLabs\LaravelSpatial\Types\Polygon;
+
+/**
+ * Class Region
+ *
+ * @method void selectDistanceTo(Builder $query, string $column, Point $point)
+ * @method void orderByDistanceTo(Builder $query, string $column, Point $point, string $direction = 'asc')
+ * @method void withinDistanceTo(Builder $query, string $column, Point $point, int $distance)
+ *
+ * @property Point location
+ * @property Polygon area
+ */
+class Region extends Model
+{
+    use HasSpatial;
+
+    protected $fillable = [
+        'location',
+        'area',
+    ];
+
+    protected $casts = [
+        'location' => LocationCast::class,
+        'area'     => RegionCast::class,
+    ];
+}

--- a/tests/database/migrations/0000_00_00_000001_create_places_table.php
+++ b/tests/database/migrations/0000_00_00_000001_create_places_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('places', function (Blueprint $table) {
+            $table->id();
+            $table->geography('area', subtype: 'polygon')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('places');
+    }
+};

--- a/tests/database/migrations/0000_00_00_000002_create_regions_table.php
+++ b/tests/database/migrations/0000_00_00_000002_create_regions_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('regions', function (Blueprint $table) {
+            $table->id();
+            $table->geography('location', subtype: 'point')->nullable();
+            $table->geography('area', subtype: 'polygon')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('regions');
+    }
+};


### PR DESCRIPTION
- Implemented the RegionCast, that indicates a polygon into a geographic location.
- Adapted "HasSpatial" trait so it can recognize the RegionCast.
- Renamed "HasSpatialTest" as "HasSpatialPoint" test.
- Implemented "HasSpatialPolygonTest".
- Implemented "HasSpatialTest" so it can test models with the combination of different casts.